### PR TITLE
Add "source" and "target" values for maven-compiler-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # mySeleniumProject
+
+Run maven commands using docker through the following command:
+
+```sh
+docker-compose run mvn <command>
+```
+
+Check `mvn --help` (as described below) in order to get to know it more.
+
+```sh
+docker-compose run mvn --help
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3'
+
+services:
+  mvn:
+    entrypoint: mvn
+    image: maven:alpine
+    volumes:
+      - ${PWD}:/usr/src/app
+      - .m2:${HOME}/.m2
+    working_dir: /usr/src/app

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,8 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.3</version>
         <configuration>
-          <source/>
-          <target/>
+          <source>7</source>
+          <target>7</target>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
This should fix an error which happens during build procedure, suggesting the v7 (or latest) source due to the use of switch with strings.